### PR TITLE
chore : Added OneTab extension

### DIFF
--- a/src/DB/product.json
+++ b/src/DB/product.json
@@ -1118,5 +1118,12 @@
     "image": "https://rb.gy/fcnrr",
     "link": "https://www.beautiful.ai/",
     "description": "Helps you create stunning presentations in minutes."
+  },
+  {
+    "productName": "OneTab",
+    "category": "extensions",
+    "image": "https://bit.ly/3BsSmX2",
+    "link": "https://bit.ly/3Ocgoxe",
+    "description": "OneTab convert all of your tabs into a list and saves them"
   }
 ]


### PR DESCRIPTION
Whenever you find yourself with too many tabs, click the OneTab icon to convert all of your tabs into a list. When you need to access the tabs again, you can either restore them individually or all at once.

When your tabs are in the OneTab list, you will save up to 95% of memory because you will have reduced the number of tabs open in Google Chrome.