### PR TITLE
replaces broken image url

### DIFF
--- a/src/DB/product.json
+++ b/src/DB/product.json
@@ -23,7 +23,7 @@
   {
     "productName": "Awesome Screen Capture And Recorder",
     "category": "tools",
-    "image": "https://ibb.co/5h1yDpv",
+    "image": "https://avatars.slack-edge.com/2019-03-29/593781862471_95d3bb4cccb9b58821be_512.png",
     "link": "https://www.awesomescreenshot.com/",
     "description": "A tool that is used to capture customize screenshot and screen recorder"
   },


### PR DESCRIPTION
Fixes #256 

<img width="352" alt="image" src="https://github.com/JasonDsouza212/free-hit/assets/60383339/c52eebef-709b-446d-b377-a60f9a89cafa">

text overflows onto the icon, will open another issue to discuss possible solutions