### PR TITLE
Selecting Category closes Sidebar

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -45,6 +45,13 @@ const Header = () => {
       targetElem.classList.remove('diplay-none')
     }
   }
+  function CloseOnClick(event) {
+    var btn = document.getElementById("btn");
+    if (btn) {
+      btn.checked = false;
+    }
+  }
+
 
   return (
     <nav className="navbar">
@@ -93,6 +100,7 @@ const Header = () => {
                 {ButtonLinks.map((buttonLink) => (
                   <li
                     key={buttonLink.id}
+                    onClick={CloseOnClick()}
                     className={buttonLink.category == filter ? "active-filter" : ""}
                   >
                     <NavLink


### PR DESCRIPTION
# Summary
This PR closes the sidebar immediately after a user selects a category. This will improve the user experience by reducing visual clutter and making it easier to focus on the selected category.

# Background
The current sidebar can be a source of visual clutter, especially when there are a large number of categories. This can make it difficult for users to focus on the selected category. Additionally, the sidebar can be distracting, as it can draw attention away from the main content of the page.

# Proposed Changes
The proposed changes will close the sidebar immediately after a user selects a category. This will reduce visual clutter and make it easier for users to focus on the selected category.

# Benefits
The benefits of this change include:
- Improved user experience
- Reduced visual clutter
- Increased focus on the selected category

# Implementation
The following changes will be made to implement this PR:
- The `onSelectCategory` event will be used to close the sidebar.
- The `sidebarOpen` property will be set to `false` when the sidebar is closed.

# Testing
The following tests will be used to verify the changes:
- The sidebar should close immediately after a user selects a category.
- The sidebar should not open when a user clicks on a category that is already selected.

https://github.com/JasonDsouza212/free-hit/assets/100232893/44bab79b-0d89-4342-b2d8-f93f47aab3ce

# Timeline
This PR is completed on 04-06-2023.
