### PR TITLE
💡 [FEAT]: MADE SOCIAL ANCHORS ACCESSIBLE ON FOOTER

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -20,17 +20,32 @@ const Footer = () => {
         </p>
         <ul className="socials">
           <li>
-            <a target="_blank" href="https://twitter.com/_Jason_Dsouza">
+            <a 
+              aria-label="Follow me on Facebook"
+              title="Facebook (External Link)"
+              rel="noopener noreferrer"
+              target="_blank" 
+              href="https://twitter.com/_Jason_Dsouza"
+            >
               <i className="socials_twitter ri-twitter-fill"></i>
             </a>
           </li>
           <li>
-            <a target="_blank" href="https://github.com/JasonDsouza212">
+            <a 
+              aria-label="Follow me on Github"
+              title="Github (External Link)"
+              rel="noopener noreferrer"
+              target="_blank" 
+              href="https://github.com/JasonDsouza212"
+            >
               <i className="socials_github ri-github-fill"></i>
             </a>
           </li>
           <li>
             <a
+              aria-label="Follow me on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer"
               target="_blank"
               href="https://www.linkedin.com/in/jason-dsouza-130b421ba/"
             >
@@ -38,7 +53,13 @@ const Footer = () => {
             </a>
           </li>
           <li>
-            <a target="_blank" href="mailto:jasondsouza212@gmail.com">
+            <a
+              aria-label="Mail me on jasondsouza212@gmail.com"
+              title="Mail (External Link)"
+              rel="noopener noreferrer"
+              target="_blank" 
+              href="mailto:jasondsouza212@gmail.com"
+            >
               <i className="socials_mail ri-mail-fill"></i>
             </a>
           </li>


### PR DESCRIPTION
## Related Issue

Closes #966 

## Description
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Checklist

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
