### PR TITLE
feat: add nav bar theme toggle feature ✨

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta name="theme-color" content="#000000" />
     <meta name="title" content="Free-Hit" />
     <meta
       name="description"
@@ -20,6 +19,12 @@
     <link href="https://cdn.jsdelivr.net/npm/remixicon@2.5.0/fonts/remixicon.css" rel="stylesheet">
     <link rel="apple-touch-icon" href="/favicon.ico" />
     <title>FREE-HIT</title>
+
+    <!-- Nav Bar Theme -->
+    <meta name="theme-color" content="currentcolor">
+    <meta name="msapplication-navbutton-color" content="currentcolor">
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="currentcolor">
 
     <!-- Open Graph / Facebook -->
     <meta property="og:type" content="website" />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -60,6 +60,9 @@ const Card = () => {
   // darkmode function
   const toggleDarkMode = () => {
     setDarkMode(!darkMode);
+
+    // Changing the nav bar theme during toggle
+    document.querySelector('meta[name="theme-color"]').setAttribute('content', darkMode ? '#373530' : '#f1f1ef');
   };
 
   return (


### PR DESCRIPTION

## Related Issue

Closes #1007 

## Description
- Added navigation bar theme toggle feature.
- This feature will work along with `setDarkMode()` function, it can update the site's nav bar theme color.
- Additionally i added neccessary html meta elements to change the theme in order to with `currentcolor` where it can updated during the page load and updated during `setDarkMode()` invoked.
- I added few more recent theme elements which will work fine for browsers like IE, Safari.
- An important note is this nav bar preference of changing themes manually is still in development, so most of browsers will not support right now. But we can assure that this feature will globally add soon. 

## Screenshots
![Screenshot_2023-07-03-19-42-47_1366x768](https://github.com/JasonDsouza212/free-hit/assets/92252895/55e95efa-ff92-4444-afb2-95ba2672d561)
![Screenshot_2023-07-03-19-44-15_1366x768](https://github.com/JasonDsouza212/free-hit/assets/92252895/e468bddc-d0eb-4ba1-ac6b-8c5da2e8c8c7)

## Checklist

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
