### PR TITLE
feat: make social anchors accessible for profile cards on team.jsx ✨

### DIFF
--- a/src/components/Team.jsx
+++ b/src/components/Team.jsx
@@ -25,13 +25,28 @@ const Team = () => {
           <h5 className={darkMode ? 'dark-mode' : ''}
                   activeclassname="active">Designer</h5>
           <div className={`icons ${darkMode ? 'dark-mode' : ''}`}>
-            <a href="https://twitter.com/bobsstwt" target="_blank">
+            <a 
+              aria-label="Follow me on Twitter"
+              title="Twitter (External Link)"
+              rel="noopener noreferrer"
+              href="https://twitter.com/bobsstwt" 
+              target="_blank"
+            >
               <i className={`ri-twitter-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
-            <a href="https://github.com/bobbyy16" target="_blank">
+            <a
+              aria-label="Follow me on Github"
+              title="Github (External Link)"
+              rel="noopener noreferrer"
+              href="https://github.com/bobbyy16" 
+              target="_blank"
+            >
               <i className={`ri-github-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
             <a
+              aria-label="Follow me on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer"
               href="https://www.linkedin.com/in/abhishek-k-7597771ba/"
               target="_blank"
             >
@@ -47,13 +62,31 @@ const Team = () => {
           <h5 className={darkMode ? 'dark-mode' : ''}
                   activeclassname="active">Developer</h5>
           <div className="icons">
-            <a href="https://twitter.com/Priyankarpal" target="_blank">
+            <a 
+              aria-label="Follow me on Twitter"
+              title="Twitter (External Link)"
+              rel="noopener noreferrer"
+              href="https://twitter.com/Priyankarpal" 
+              target="_blank"
+            >
               <i className={`ri-twitter-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
-            <a href="https://github.com/priyankarpal" target="_blank">
+            <a 
+              aria-label="Follow me on Github"
+              title="Github (External Link)"
+              rel="noopener noreferrer"
+              href="https://github.com/priyankarpal" 
+              target="_blank"
+            >
               <i className={`ri-github-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
-            <a href="https://www.linkedin.com/in/priyankarpal/" target="_blank">
+            <a 
+              aria-label="Follow me on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer"
+              href="https://www.linkedin.com/in/priyankarpal/" 
+              target="_blank"
+            >
               <i className={`ri-linkedin-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
           </div>
@@ -66,13 +99,28 @@ const Team = () => {
           <h5 className={darkMode ? 'dark-mode' : ''}
                   activeclassname="active">Developer</h5>
           <div className="icons">
-            <a href="https://twitter.com/_Jason_Dsouza" target="_blank">
+            <a 
+              aria-label="Follow me on Twitter"
+              title="Twitter (External Link)"
+              rel="noopener noreferrer"
+              href="https://twitter.com/_Jason_Dsouza" 
+              target="_blank"
+            >
               <i className={`ri-twitter-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
-            <a href="http://github.com/JasonDsouza212" target="_blank">
+            <a 
+              aria-label="Follow me on Github"
+              title="Github (External Link)"
+              rel="noopener noreferrer"
+              href="http://github.com/JasonDsouza212" 
+              target="_blank"
+            >
               <i className={`ri-github-fill ${darkMode ? 'dark-mode' : ''}`}></i>
             </a>
             <a
+              aria-label="Follow me on Linkedin"
+              title="Linkedin (External Link)"
+              rel="noopener noreferrer"
               href="https://www.linkedin.com/in/jason-dsouza-130b421ba/"
               target="_blank"
             >


### PR DESCRIPTION
## Related Issue

Closes #1197 

## Description
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

<!-- Add screenshots to preview the changes  -->

## Checklist

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
