### PR TITLE
fix: copyright section bad text contrast 🛠

### DIFF
--- a/src/styles/Footer.css
+++ b/src/styles/Footer.css
@@ -87,8 +87,9 @@ footer {
 }
 .footer-bottom span {
   text-transform: uppercase;
-  opacity: 0.4;
-  font-weight: 200;
+  opacity: .75;
+  font-weight: 400;
+  letter-spacing: .02rem;
 }
 .footer-bottom ul {
   margin: 0;


### PR DESCRIPTION
## Related Issue

Closes #1201 

## Description
- This PR is about fixing the bad color contrast of copyright text section, which is way more important to improve visual accessibility of our website

## Screenshots

| BEFORE | AFTER |
| :--: | :--: |
| ![image](https://github.com/JasonDsouza212/free-hit/assets/92252895/b713d401-cd44-43ef-b6ff-adeec41e81ba) | ![image](https://github.com/JasonDsouza212/free-hit/assets/92252895/c1ab9d3f-729a-4d3e-bde8-6ebf2d6e7c34) |

## Checklist

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
