### PR TITLE
fix: added the linkedin button in about sidebar #1559

### DIFF
--- a/src/components/LinkedInButton.jsx
+++ b/src/components/LinkedInButton.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { linkedMsg } from '../utils/data/message';
+
+const LinkedInButton = () => {
+  const handleClick = () => {
+    const linkedinUrl = linkedMsg
+    window.open(linkedinUrl, '_blank')
+  }
+
+  return (
+    <a href="#" onClick={handleClick}>
+      <i className="ri-linkedin-fill"></i> Share on
+    </a>
+  )
+}
+
+export default LinkedInButton;

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -5,6 +5,7 @@ import { msg } from '../utils/data/message';
 import ButtonLinks from '../utils/data/categories';
 import { useContext, useEffect, useState } from 'react';
 import { ToolContext } from '../App';
+import LinkedInButton from './LinkedInButton';
 
 export default function Sidebar({search}) {
   const location = useLocation();
@@ -80,6 +81,9 @@ export default function Sidebar({search}) {
 					<li className='about-list'>
 						<TwitterButton message={msg} />
 					</li>
+          <li className='about-list'>
+            <LinkedInButton />
+          </li>
 				</ul>
 			</nav>
       ) : (

--- a/src/utils/data/message.js
+++ b/src/utils/data/message.js
@@ -3,3 +3,5 @@ Check out Free-Hit🏏, an open-source App for discovering free and helpful tool
 It's a one-stop solution for finding amazing resources
 Don't forget to give it a⭐️and explore it on GitHub 
 https://github.com/JasonDsouza212/free-hit`
+
+export const linkedMsg = `https://www.linkedin.com/shareArticle?mini=true&url=https://free-hit.vercel.app/`


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #1559 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
### `Under GSSOC'23`

- Added the LinkedIn share button in the sidebar of the About section.
- After clicking it will redirect to the linkedin sharing page where you can share it in a DM or as a post.

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

## Screenshots
![linkedin-new](https://github.com/JasonDsouza212/free-hit/assets/91179998/dd5ab8bc-a235-424b-9e64-29db7fa4edde)

**Video:**

https://github.com/JasonDsouza212/free-hit/assets/91179998/138f0b3b-83ab-4755-9e09-577bef87fb70


<!-- Add screenshots to preview the changes  -->

## Checklist

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.
