### PR TITLE
Add Auferet to Gaming

### DIFF
--- a/src/DB/product.json
+++ b/src/DB/product.json
@@ -3831,5 +3831,12 @@
   "image": "https://typora.io/img/icon_256x256.png",
   "link": "https://typora.io/",
   "description": "A minimal markdown editor and reader equipped with file conversion feature."
-}
+},
+  {
+    "productName": "Auferet",
+    "category": "Gaming",
+    "image": "https://auferet.com/favicon.ico",
+    "link": "https://auferet.com",
+    "description": "AI game master for solo text adventures and tabletop RPGs that remembers your story and reads your uploaded lore."
+  }
 ]


### PR DESCRIPTION
Adds **Auferet** to the Gaming category.

Auferet is an AI game master for solo text adventures and tabletop-style RPGs, with long-term story memory and your own uploaded lore. The free tier gives 10 actions a day. Entry follows the existing schema.
